### PR TITLE
Stack event callbacks

### DIFF
--- a/src/swing-stack-component.ts
+++ b/src/swing-stack-component.ts
@@ -1,6 +1,6 @@
 declare var require: any;
 
-import {Component, ContentChildren, QueryList, AfterContentInit } from '@angular/core';
+import {Component, ContentChildren, QueryList, AfterContentInit, EventEmitter } from '@angular/core';
 import {SwingCardComponent} from './swing-card-component';
 
 const Swing = require('swing');
@@ -9,9 +9,29 @@ const Swing = require('swing');
   selector: '[swing-stack]',
   template: `
     <ng-content></ng-content>
-  `
+  `,
+  outputs: [
+    'throwout',
+    'throwoutend',
+    'throwoutleft',
+    'throwoutright',
+    'throwin',
+    'throwinend',
+    'dragstart',
+    'dragmove',
+    'dragend',
+  ]
 })
 export class SwingStackComponent implements AfterContentInit {
+  throwout: EventEmitter<any> = new EventEmitter();
+  throwoutend: EventEmitter<any> = new EventEmitter();
+  throwoutleft: EventEmitter<any> = new EventEmitter();
+  throwoutright: EventEmitter<any> = new EventEmitter();
+  throwin: EventEmitter<any> = new EventEmitter();
+  throwinend: EventEmitter<any> = new EventEmitter();
+  dragstart: EventEmitter<any> = new EventEmitter();
+  dragmove: EventEmitter<any> = new EventEmitter();
+  dragend: EventEmitter<any> = new EventEmitter();
 
   cards: SwingCardComponent[];
   stack: any;
@@ -30,5 +50,41 @@ export class SwingStackComponent implements AfterContentInit {
   ngAfterContentInit() {
     this.stack = Swing.Stack({});
     this.cards.forEach((c) => this.stack.createCard(c.getNativeElement()));
+
+    this.stack.on('throwout', ($event) => {
+      this.throwout.emit($event);
+    });
+
+    this.stack.on('throwoutend', ($event) => {
+      this.throwoutend.emit($event);
+    });
+
+    this.stack.on('throwoutleft', ($event) => {
+      this.throwoutleft.emit($event);
+    });
+
+    this.stack.on('throwoutright', ($event) => {
+      this.throwoutright.emit($event);
+    });
+
+    this.stack.on('throwin', ($event) => {
+      this.throwin.emit($event);
+    });
+
+    this.stack.on('throwinend', ($event) => {
+      this.throwinend.emit($event);
+    });
+
+    this.stack.on('dragstart', ($event) => {
+      this.dragstart.emit($event);
+    });
+
+    this.stack.on('dragmove', ($event) => {
+      this.dragmove.emit($event);
+    });
+
+    this.stack.on('dragend', ($event) => {
+      this.dragend.emit($event);
+    });
   }
 }


### PR DESCRIPTION
Throw [Swing](https://github.com/gajus/swing) events from Stack.

| Name | Description |
| --- | --- |
| `throwout` | When card has been thrown out of the stack. |
| `throwoutend` | When card has been thrown out of the stack and the animation has ended. |
| `throwoutleft` | Shorthand for `throwout` event in the `Card.DIRECTION_LEFT` direction. |
| `throwoutright` | Shorthand for `throwout` event in the `Card.DIRECTION_RIGHT` direction. |
| `throwin` | When card has been thrown into the stack. |
| `throwinend` | When card has been thrown into the stack and the animation has ended. |
| `dragstart` | Hammer [panstart](http://hammerjs.github.io/recognizer-pan/). |
| `dragmove` | Hammer [panmove](http://hammerjs.github.io/recognizer-pan/). |
| `dragend` | Hammer [panend](http://hammerjs.github.io/recognizer-pan/). |

# Pending
Throw events from cards