### PR TITLE
Added support for throwOutConfidence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ import {Component, ViewChild, ViewChildren, QueryList} from '@angular/core';
 import {
   Stack,
   Card,
-  ThrowEvent,
-  DragEvent,
+  SwingEvent,
+  StackConfig,
   SwingStackComponent,
   SwingCardComponent} from 'angular2-swing';
 
@@ -20,7 +20,7 @@ import {
   directives: [SwingStackComponent, SwingCardComponent],
   template: `
     <div id="viewport">
-      <ul class="stack" swing-stack #myswing1 (throwout)="onThrowOut($event)">
+      <ul class="stack" swing-stack [config]="stackConfig" #myswing1 (throwout)="onThrowOut($event)">
         <li swing-card #mycards1 [ngClass]="c.name" *ngFor="let c of cards">{{ c.symbol }}</li>
       </ul>
     </div>
@@ -43,9 +43,15 @@ export class App {
   @ViewChildren('mycards1') swingCards: QueryList<SwingCardComponent>;
 
   cards: Array<any>;
+  stackConfig: StackConfig;
 
   constructor() {
-
+    this.stackConfig = {
+        throwOutConfidence: (offset, element) => {
+            //override default throwout detection with one twice as sensitive
+            return Math.min(Math.abs( offset ) / (element.offsetWidth / 2), 1);
+        }
+    }
     this.cards = [
       { name: 'clubs', symbol: '♣' },
       { name: 'diamonds', symbol: '♦' },
@@ -71,9 +77,9 @@ export class App {
     // this is how you can manually hook up to the
     // events instead of providing the event method in the template
     this.swingStack.throwoutleft.subscribe(
-      (event: ThrowEvent) => console.log('Manual hook: ', event));
+      (event: SwingEvent) => console.log('Manual hook: ', event));
 
-    this.swingStack.dragstart.subscribe((event: DragEvent) => console.log(event));
+    this.swingStack.dragstart.subscribe((event: SwingEvent) => console.log(event));
   }
 
   // This method is called by hooking up the event

--- a/src/swing-stack-component.ts
+++ b/src/swing-stack-component.ts
@@ -3,7 +3,7 @@ declare var require: any;
 import {Component, ContentChildren, QueryList,
   AfterContentInit, EventEmitter } from '@angular/core';
 
-import { ThrowDirection, ThrowEvent, DragEvent, Stack, Card} from './swing';
+import { ThrowDirection, SwingEvent, Stack, StackConfig, Card} from './swing';
 import {SwingCardComponent} from './swing-card-component';
 
 const Swing = require('swing');
@@ -13,6 +13,9 @@ const Swing = require('swing');
   template: `
     <ng-content></ng-content>
   `,
+  inputs: [
+    'config'
+  ],
   outputs: [
     'throwout',
     'throwoutend',
@@ -27,19 +30,20 @@ const Swing = require('swing');
 })
 export class SwingStackComponent implements AfterContentInit {
 
-  throwout: EventEmitter<ThrowEvent> = new EventEmitter();
-  throwoutend: EventEmitter<ThrowEvent> = new EventEmitter();
-  throwoutleft: EventEmitter<ThrowEvent> = new EventEmitter();
-  throwoutright: EventEmitter<ThrowEvent> = new EventEmitter();
-  throwin: EventEmitter<ThrowEvent> = new EventEmitter();
-  throwinend: EventEmitter<ThrowEvent> = new EventEmitter();
+  throwout: EventEmitter<SwingEvent> = new EventEmitter();
+  throwoutend: EventEmitter<SwingEvent> = new EventEmitter();
+  throwoutleft: EventEmitter<SwingEvent> = new EventEmitter();
+  throwoutright: EventEmitter<SwingEvent> = new EventEmitter();
+  throwin: EventEmitter<SwingEvent> = new EventEmitter();
+  throwinend: EventEmitter<SwingEvent> = new EventEmitter();
 
-  dragstart: EventEmitter<DragEvent> = new EventEmitter();
-  dragmove: EventEmitter<DragEvent> = new EventEmitter();
-  dragend: EventEmitter<DragEvent> = new EventEmitter();
+  dragstart: EventEmitter<SwingEvent> = new EventEmitter();
+  dragmove: EventEmitter<SwingEvent> = new EventEmitter();
+  dragend: EventEmitter<SwingEvent> = new EventEmitter();
 
   cards: SwingCardComponent[];
   stack: Stack;
+  config: StackConfig;
 
   constructor() {
     this.cards = [];
@@ -53,7 +57,7 @@ export class SwingStackComponent implements AfterContentInit {
   }
 
   ngAfterContentInit() {
-    this.stack = Swing.Stack({});
+    this.stack = Swing.Stack(this.config ? this.config : {});
     this.cards.forEach((c) => this.stack.createCard(c.getNativeElement()));
 
     // Hook various events

--- a/src/swing.ts
+++ b/src/swing.ts
@@ -7,13 +7,10 @@ export enum ThrowDirection {
   RIGHT = 1
 }
 
-export interface ThrowEvent {
+export interface SwingEvent {
   target: HTMLElement;
-  throwDirection: ThrowDirection;
-}
-
-export interface DragEvent {
-  target: HTMLElement;
+  throwDirection?: ThrowDirection;
+  throwOutConfidence?: number;
 }
 
 export type ThrowEventName = 'throwin' | 'throwinend' |
@@ -26,14 +23,18 @@ export interface Card {
   throwIn(x: number, y: number): void;
   throwOut(x: number, y: number): void;
 
-  on(eventName: ThrowEventName, callabck: (event: ThrowEvent) => void): void;
-  on(eventName: DragEventName, callabck: (event: DragEvent) => void): void;
+  on(eventName: ThrowEventName, callabck: (event: SwingEvent) => void): void;
+  on(eventName: DragEventName, callabck: (event: SwingEvent) => void): void;
+}
+
+export interface StackConfig {
+  throwOutConfidence?: (offset: number, elment: HTMLElement) => number;
 }
 
 export interface Stack {
   createCard(elment: HTMLElement): void;
   getCard(element: HTMLElement): Card;
 
-  on(eventName: ThrowEventName, callabck: (event: ThrowEvent) => void): void;
-  on(eventName: DragEventName, callabck: (event: DragEvent) => void): void;
+  on(eventName: ThrowEventName, callabck: (event: SwingEvent) => void): void;
+  on(eventName: DragEventName, callabck: (event: SwingEvent) => void): void;
 }


### PR DESCRIPTION
Can now provide throwOutConfidence function as an input to the stack component.
Can now get a value of throwOutConfidence in events.

To simplify the existence of throwOutConfidence in the events I've merged ThrowEvent and DragEvent into SwingEvent. The alternative was to make DragMoveEvent, DragEvent, ThrowEvent.
(My solution has broken backwards compatibility - up to you if you want to merge this given that).

I have not made a corresponding update to the sample project.
