### PR TITLE
Fix for issue #10 - use in Ionic 2 with rollup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 
-export * from './swing-stack-component';
-export * from './swing-card-component';
-export * from './swing';
-export * from './swing.module';
+export { SwingStackComponent } from './swing-stack-component';
+export { SwingCardComponent } from './swing-card-component';
+export {
+    ThrowDirection,
+    ThrowEvent,
+    DragEvent,
+    ThrowEventName,
+    DragEventName,
+    Card,
+    Stack,
+    StackConfig } from './swing';
+export { SwingModule } from './swing.module';


### PR DESCRIPTION
Explicitly list all the names of what we're exporting for the sake of…rollup (which is used by Ionic 2 RC 0 where I imagine the Swing library will be often used).