### PR TITLE
Adding destroyCard() function to swing-card-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/ksachdeva/angular2-swing#readme",
   "dependencies": {
-    "swing": "^4.3.0"
+    "swing": "^3.1.1"
   },
   "devDependencies": {
     "@angular/common": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/ksachdeva/angular2-swing#readme",
   "dependencies": {
-    "swing": "^3.1.0"
+    "swing": "^4.3.0"
   },
   "devDependencies": {
     "@angular/common": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/ksachdeva/angular2-swing#readme",
   "dependencies": {
-    "swing": "^4.3.0"
+    "swing": "^3.1.0"
   },
   "devDependencies": {
     "@angular/common": "^4.0.0",

--- a/src/swing-card-component.ts
+++ b/src/swing-card-component.ts
@@ -31,4 +31,10 @@ export class SwingCardComponent {
   getCard(): Card {
     return this.swingStack.stack.getCard(this.getNativeElement());
   }
+
+  destroyCard() {
+		this.swingStack.cards.pop();
+		var card = this.swingStack.stack.getCard(this.getNativeElement());
+		this.swingStack.stack.destroyCard(card);
+	}
 }

--- a/src/swing-card-component.ts
+++ b/src/swing-card-component.ts
@@ -11,6 +11,8 @@ import {Card} from './swing';
 export class SwingCardComponent {
   @Input() prepend: boolean = false;
 
+  card: Card;
+
   constructor(
     private elmentRef: ElementRef,
     private swingStack: SwingStackComponent) {
@@ -33,8 +35,8 @@ export class SwingCardComponent {
   }
 
   destroyCard() {
-		this.swingStack.cards.pop();
-		var card = this.swingStack.stack.getCard(this.getNativeElement());
-		this.swingStack.stack.destroyCard(card);
-	}
+    this.swingStack.cards = this.swingStack.cards.filter(swingCardComponent => swingCardComponent !== this);
+    let card = this.swingStack.stack.getCard(this.getNativeElement());
+    this.swingStack.stack.destroyCard(card);
+  }
 }

--- a/src/swing.ts
+++ b/src/swing.ts
@@ -93,6 +93,12 @@ export interface Stack {
    */
   getCard(element: HTMLElement): Card;
 
+   /**
+    *
+  	*@param {Card} card
+  	*/
+   destroyCard(card: Card): void;
+  
   on(eventName: ThrowEventName, callabck: (event: ThrowEvent) => void): void;
   on(eventName: DragEventName, callabck: (event: DragEvent) => void): void;
 }

--- a/src/swing.ts
+++ b/src/swing.ts
@@ -93,12 +93,12 @@ export interface Stack {
    */
   getCard(element: HTMLElement): Card;
 
-   /**
-    *
-  	*@param {Card} card
-  	*/
-   destroyCard(card: Card): void;
-  
+  /**
+   *
+   *@param {Card} card
+   */
+  destroyCard(card: Card): void;
+
   on(eventName: ThrowEventName, callabck: (event: ThrowEvent) => void): void;
   on(eventName: DragEventName, callabck: (event: DragEvent) => void): void;
 }


### PR DESCRIPTION
@mashhoodr I hope you're ok to merge this? This is because the other event listeners on swing-stack-component are listening for GUI events and destroyCard() is more like an application related thing that you may or may not want to happen. Hope this makes sense. I have tested and it works for me. No longer getting build up of cards on the stack.